### PR TITLE
fix: handling of Array js builtin

### DIFF
--- a/__testfixtures__/edge-cases.input.ts
+++ b/__testfixtures__/edge-cases.input.ts
@@ -37,5 +37,3 @@ function validateData(data: any) {
 
 // do not modify Javascript built-in array prototype
 const array = Array(5).keys()
-
-const string = String('asdf')

--- a/__testfixtures__/edge-cases.input.ts
+++ b/__testfixtures__/edge-cases.input.ts
@@ -34,3 +34,8 @@ function validateData(data: any) {
   }
   return false;
 }
+
+// do not modify Javascript built-in array prototype
+const array = Array(5).keys()
+
+const string = String('asdf')

--- a/__testfixtures__/edge-cases.output.ts
+++ b/__testfixtures__/edge-cases.output.ts
@@ -37,3 +37,6 @@ function validateData(data: any) {
   }
   return false;
 }
+
+// do not modify Javascript built-in array prototype
+const array = Array(5).keys()

--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -466,6 +466,9 @@ describe("specific transformations", () => {
     );
 
     expect(normalizedOutput).not.toContain("z.boolean()(");
+    
+    // Array should not be transformed because it was not imported from runtypes
+    expect(normalizedOutput).not.toContain("z.array(5).keys()");
   });
 
   test("correctly handles Symbol usage", () => {


### PR DESCRIPTION
This previously transformed `Array` instances that weren't imported from runtypes, which breaks things. 

![Screenshot 2025-04-09 at 14 14 48](https://github.com/user-attachments/assets/7a4ccd32-5886-439b-97f3-9802876ee094)
